### PR TITLE
メンバー欄更新と認証トークンの切り替え

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,15 @@ on:
       - main
     types:
       - closed
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - name: checkout branch 
         uses: actions/checkout@v2
@@ -39,7 +44,8 @@ jobs:
         run: |
            mkdocs build --verbose --clean --strict
       - name: mkdocs deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
-           github_token: ${{ secrets.PERSONAL_TOKEN }}
+           github_token: ${{ secrets.GITHUB_TOKEN }}
            publish_dir: site
+           publish_branch: test-gh-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: setup python env
         uses: actions/setup-python@v1
         with:
-          python-version: '3.8'
+          python-version: '3.13'
 
       - name: install dependencies
         run: |
@@ -48,4 +48,3 @@ jobs:
         with:
            github_token: ${{ secrets.GITHUB_TOKEN }}
            publish_dir: site
-           publish_branch: test-gh-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,15 @@ on:
       - main
     types:
       - closed
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - name: checkout branch 
         uses: actions/checkout@v2
@@ -39,7 +44,7 @@ jobs:
         run: |
            mkdocs build --verbose --clean --strict
       - name: mkdocs deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
-           github_token: ${{ secrets.PERSONAL_TOKEN }}
+           github_token: ${{ secrets.GITHUB_TOKEN }}
            publish_dir: site

--- a/.github/workflows/build_manually.yml
+++ b/.github/workflows/build_manually.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+          contents: write
+          pages: write
+          id-token: write
     steps:
       - name: checkout branch 
         uses: actions/checkout@v2
@@ -37,7 +41,7 @@ jobs:
         run: |
            mkdocs build --verbose --clean --strict
       - name: mkdocs deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
-           github_token: ${{ secrets.PERSONAL_TOKEN }}
+           github_token: ${{ secrets.GITHUB_TOKEN }}
            publish_dir: site

--- a/docs/en/members.md
+++ b/docs/en/members.md
@@ -27,6 +27,7 @@
 - Marsha Nabilah Wibowo
 - Lian Hong
 - Yichen Wang
+- Yuehan Zhang
 		
 ## Undergraduate students
 - Kaho Ishida
@@ -39,4 +40,3 @@
 
 ## Research students
 - Tanjila Akter Tithi
-- Yuehan Zhang

--- a/docs/ja/members.md
+++ b/docs/ja/members.md
@@ -27,6 +27,7 @@
 - 西村 涼 (Ryo Nishimura)
 - 洪 瀲（Lian Hong）
 - 王 軼琛（Yichen Wang）
+- 張 悦翰（Yuehan Zhang）
 
 ## 学部生 (Undergraduate students)
 - 石田 果歩 (Kaho Ishida)
@@ -39,4 +40,3 @@
 
 ## 研究生 (Research students)
 - Tanjila Akter Tithi
-- 張 悦翰（Yuehan Zhang）


### PR DESCRIPTION
認証方式をgithub-tokenに変更し，個人トークンを発行せずにデプロイができるよう修正しました．